### PR TITLE
[recovery] upgrade minimist to ^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "parse arguments with recursive contexts",
   "main": "index.js",
   "dependencies": {
-    "minimist": "~0.0.7"
+    "minimist": "^1.1.0"
   },
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
https://web.archive.org/web/20201110211142/https://github.com/substack/subarg/pull/2

filed by @mantoni

> I'd like to use the `unknown` option with subarg that was recently introduced in minimist.

[Response](https://web.archive.org/web/20201110211142/https://github.com/substack/subarg/pull/2#issuecomment-57828137) by @substack:
> Merged in 1.0.0. Thanks for the patch!