### PR TITLE
Minimist version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -3,16 +3,16 @@ var minimist = require('minimist');
 module.exports = function parse (args, opts) {
     var level = 0, index;
     var args_ = [];
-    
+
     for (var i = 0; i < args.length; i++) {
         if (typeof args[i] === 'string' && /^\[/.test(args[i])) {
             if (level ++ === 0) {
                 index = i;
             }
         }
-        if (typeof args[i] === 'string' && /\]$/.test(args[i])) {
+        if (typeof args[i] === 'string' && /^\[?[^\[]*\]$/.test(args[i])) {
             if (-- level > 0) continue;
-            
+
             var sub = args.slice(index, i + 1);
             if (typeof sub[0] === 'string') {
                 sub[0] = sub[0].replace(/^\[/, '');
@@ -24,12 +24,12 @@ module.exports = function parse (args, opts) {
                 sub[n] = sub[n].replace(/\]$/, '');
             }
             if (sub[n] === '') sub.pop();
-            
+
             args_.push(parse(sub));
         }
         else if (level === 0) args_.push(args[i]);
     }
-    
+
     var argv = minimist(args_, opts);
     return argv;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,124 @@
+{
+  "name": "@minimistjs/subarg",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@minimistjs/subarg",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ==",
+      "dev": true
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha512-8WvkvUZiKAjjsy/63rJjA7jw9uyF0CLVLjBKEfnPHE3Jxvs1LgwqL2OmJN+LliIX1vrzKW+AAu02Cc+xv27ncQ==",
+      "dev": true
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
+    },
+    "node_modules/tape": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-3.6.1.tgz",
+      "integrity": "sha512-Qy+shSMwr+bg5NwJhrdCKNOS7BEoo/SEjE+dF4a2OYR73f6ocH5ioLIHE6TuttjONmR3HYlOXwSqFTxUDFJtGg==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "~3.2.9",
+        "inherits": "~2.0.1",
+        "object-inspect": "~0.4.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "parse arguments with recursive contexts",
   "main": "index.js",
   "dependencies": {
-    "minimist": "^1.1.0"
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "tape": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimistjs/subarg",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "parse arguments with recursive contexts",
   "main": "index.js",
   "dependencies": {

--- a/test/inlineBrackets.js
+++ b/test/inlineBrackets.js
@@ -2,7 +2,15 @@ var subarg = require('..');
 var test = require('tape');
 
 test('inline brackets', function (t) {
-    t.plan(6);
+    t.plan(7);
+
+    t.deepEqual(
+        subarg('http://localhost\?q=\[1\]'.split(/\s+/)),
+        {
+            _: [ 'http://localhost?q=[1]' ]
+        }
+    )
+
     t.deepEqual(
         subarg('beep -t [ boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] -q]'.split(/\s+/)),
         {

--- a/test/inlineBrackets.js
+++ b/test/inlineBrackets.js
@@ -1,0 +1,124 @@
+var subarg = require('..');
+var test = require('tape');
+
+test('inline brackets', function (t) {
+    t.plan(6);
+    t.deepEqual(
+        subarg('beep -t [ boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] -q]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: [ 'http://localhost', 'http://localhost?q=[1]' ],
+                q: true
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] -q -o b.txt]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: [ 'a.txt', 'b.txt' ],
+                u: [ 'http://localhost', 'http://localhost?q=[1]' ],
+                q: true
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [ boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] ]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: [ 'http://localhost', 'http://localhost?q=[1]' ]
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [boop -o a.txt -u http://localhost\?q=\[1\] -u http://localhost]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: [ 'http://localhost?q=[1]', 'http://localhost' ]
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [ boop -o a.txt -u [beep] ]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: {
+                    _: [ 'beep' ]
+                }
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [boop] -u [ be[ep] ]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ]
+            },
+            u: {
+                _: [ 'be[ep]' ]
+            }
+        }
+    )
+});
+
+test.skip('doesnt work', function (t) {
+    t.plan(2);
+    /*
+     *  expected:
+     *    { _: [ 'beep' ], t: { _: [ 'boop' ], o: 'a.txt', u: [ 'http://localhost', 'http://localhost?q=[1]' ] } }
+     *  actual:
+     *    { _: [ 'beep' ], t: true }
+     *
+    */
+    t.deepEqual(
+        subarg('beep -t [boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\]]'.split(/\s+/)),
+        {
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: [ 'http://localhost', 'http://localhost?q=[1]' ]
+            }
+        }
+    )
+
+    t.deepEqual(
+        subarg('beep -t [ boop -o a.txt -u [be[ep] ]'.split(/\s+/)),
+        {
+            /*
+             *  expected:
+             *    { _: [ 'beep' ], t: { _: [ 'boop' ], o: 'a.txt', u: { _: [ 'beep' ] } } }
+             *  actual:
+             *    { _: [ 'beep' ], t: true }
+            */
+            _: [ 'beep'],
+            t: {
+                _: [ 'boop' ],
+                o: 'a.txt',
+                u: {
+                    _: [ 'beep' ]
+                }
+            }
+        }
+    )
+});

--- a/test/inlineBrackets.js
+++ b/test/inlineBrackets.js
@@ -111,11 +111,12 @@ test.skip('doesnt work', function (t) {
     )
 
     t.deepEqual(
-        subarg('beep -t [ boop -o a.txt -u [be[ep] ]'.split(/\s+/)),
+        subarg('beep -t [ boop -o a.txt -u [ be[ep]] ]'.split(/\s+/)),
         {
-            /*
+            /* Same as above - note the context-closing bracket is right next to an inline closing bracket
+             * If you add a space, it works
              *  expected:
-             *    { _: [ 'beep' ], t: { _: [ 'boop' ], o: 'a.txt', u: { _: [ 'beep' ] } } }
+             *    { _: [ 'beep' ], t: { _: [ 'boop' ], o: 'a.txt', u: { _: [ 'be[ep]' ] } } }
              *  actual:
              *    { _: [ 'beep' ], t: true }
             */
@@ -124,7 +125,7 @@ test.skip('doesnt work', function (t) {
                 _: [ 'boop' ],
                 o: 'a.txt',
                 u: {
-                    _: [ 'beep' ]
+                    _: [ 'be[ep]' ]
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/mcollina/autocannon/issues/520

Arg parsing fails if URL ends with ]:

The previous implementation was picking up inline(attached to the string supplied) brackets. This PR changes the regex that was used to end a context.
```
/\]$/ -> /^\[?[^\[]*\]$/
```
This change means that if an opening bracket is found inside the string(except the very first character), the regex returns false and therefore does not close the context.

The PR also updates the minimist dependency to `1.2.8` since there were critical vulnerabilities(namely, prototype pollution on versions `<=1.2.5`). I've tested autocannon to make sure the version doesnt include breaking changes, but took the liberty to bump to a major version. Feel free to change it(or comment it out so I change it) should you consider the changes not major-bump-worthy

I also took the liberty to add a `.gitignore` which includes only the `node_modules` directory.

### Tests

The following tests are all returning the correct object. There's a mix between using the closing and opening brackets(used for changing contexts) directly adjacent to the string/word and having a space inbetween.
```
subarg('http://localhost\?q=\[1\]'.split(/\s+/))
subarg('beep -t [ boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] -q]'.split(/\s+/))
subarg('beep -t [boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] -q -o b.txt]'.split(/\s+/))
subarg('beep -t [ boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\] ]'.split(/\s+/))
subarg('beep -t [boop -o a.txt -u http://localhost\?q=\[1\] -u http://localhost]'.split(/\s+/))
subarg('beep -t [ boop -o a.txt -u [beep] ]'.split(/\s+/))
subarg('beep -t [boop] -u [ be[ep] ]'.split(/\s+/))
```

The following tests are not working as expected. I've documented them(added the test cases, but the tests are skipped), but I think those are super edge-cases. If you think otherwise, let me know and I'll try to find a way to fix it

1. If the user uses a string that includes a closing bracket directly adjacent of the context closing bracket, the script doesnt work. This is easily mitigated by using a space between the two, or changing the order of the arguments(ie, using the `-u http://localhost` at the end)
```
subarg('beep -t [boop -o a.txt -u http://localhost -u http://localhost\?q=\[1\]]'.split(/\s+/))
```